### PR TITLE
Update module name regex to allow dots within module name

### DIFF
--- a/app/models/foreman_salt/salt_module.rb
+++ b/app/models/foreman_salt/salt_module.rb
@@ -9,7 +9,7 @@ module ForemanSalt
 
     has_and_belongs_to_many :hostgroups, :class_name => "::Hostgroup", :join_table => "hostgroups_salt_modules"
 
-    validates :name, :uniqueness => true, :presence => true, :format => { :with => /\A[\w\d\.]+\z/, :message => N_("is alphanumeric and cannot contain spaces") }
+    validates :name, :uniqueness => true, :presence => true, :format => { :with => /\A(?:[\w\d]+\.{0,1})+[^\.]\z/, :message => N_("must be alphanumeric, can contain dots and must not contain spaces") }
 
     default_scope lambda {
       order("salt_modules.name")


### PR DESCRIPTION
Example:

```
salt -C 'I@roles:foreman_webfrontend' state.show_top --out=json        
Executing job with jid 20140921145536094482
-------------------------------------------

{
    "ipm1021.hosted.systems": {
        "prod": [
            "crypto.x509",
            "foreman.plugins",
            "tools",
            "foreman.webfrontend",
            "httpd",
            "git",
            "network.hosts",
            "keepalived",
            "salt.minion",
            "users",
            "file.mounts",
            "linux.modules",
            "foreman.compute",
            "network.resolver",
            "time",
            "network.interfaces",
            "zsh"
        ]
    }
}
```
