### PR TITLE
Check for jenkins:unit task to enhance

### DIFF
--- a/lib/tasks/foreman_salt_tasks.rake
+++ b/lib/tasks/foreman_salt_tasks.rake
@@ -24,7 +24,7 @@ Rake::Task[:test].enhance do
 end
 
 load 'tasks/jenkins.rake'
-if Rake::Task.task_defined?(:'jenkins:setup')
+if Rake::Task.task_defined?(:'jenkins:test')
   Rake::Task["jenkins:unit"].enhance do
     Rake::Task['test:foreman_salt'].invoke
   end


### PR DESCRIPTION
Checking for jenkins:setup (a namespace) was not allowing this to run the tests, plus, the key task we have to check is jenkins:unit, which is the one we want to append our job.
