### PR TITLE
Revert "Actually run tests" and fix Jenkins rake task name

### DIFF
--- a/lib/tasks/foreman_salt_tasks.rake
+++ b/lib/tasks/foreman_salt_tasks.rake
@@ -24,6 +24,8 @@ Rake::Task[:test].enhance do
 end
 
 load 'tasks/jenkins.rake'
-Rake::Task["jenkins:unit"].enhance do
-  Rake::Task['test:foreman_salt'].invoke
+if Rake::Task.task_defined?(:'jenkins:unit')
+  Rake::Task["jenkins:unit"].enhance do
+    Rake::Task['test:foreman_salt'].invoke
+  end
 end


### PR DESCRIPTION
This reverts commit f5a971dc93e49e932b839a76ff437e636d7bf0f8 and instead tests
the correct "jenkins:unit" rake task name.
