### PR TITLE
Allow foreman_salt to run with foreman_setup

### DIFF
--- a/foreman_salt.gemspec
+++ b/foreman_salt.gemspec
@@ -13,5 +13,5 @@ Gem::Specification.new do |s|
   s.files = Dir["{app,config,db,lib}/**/*"] + ["LICENSE", "Rakefile", "README.md"]
   s.test_files = Dir["test/**/*"]
 
-  s.add_dependency "deface"
+  s.add_dependency "deface", "< 1.0"
 end


### PR DESCRIPTION
Required to fix the following error:

```
Bundler could not find compatible versions for gem "deface":
  In Gemfile:
    foreman_setup (>= 0) ruby depends on
      deface (< 1.0) ruby

    foreman_salt (>= 0) ruby depends on
      deface (1.0.1)
```
