### PR TITLE
Do not fail hard on key removal

### DIFF
--- a/app/models/foreman_salt/concerns/host_managed_extensions.rb
+++ b/app/models/foreman_salt/concerns/host_managed_extensions.rb
@@ -87,7 +87,8 @@ module ForemanSalt
       def accept_salt_key
         begin
           Rails.logger.info("Host #{fqdn} is built, accepting Salt key")
-          ForemanSalt::SmartProxies::SaltKeys.find(salt_proxy, fqdn).accept
+          key = ForemanSalt::SmartProxies::SaltKeys.find(salt_proxy, fqdn)
+          key.accept unless key.nil?
         rescue Foreman::Exception => e
            Rails.logger.warn("Unable to accept key for #{fqdn}: #{e}")
         end
@@ -95,7 +96,8 @@ module ForemanSalt
 
       def delete_salt_key
         begin
-          ForemanSalt::SmartProxies::SaltKeys.find(salt_proxy, fqdn).delete
+          key = ForemanSalt::SmartProxies::SaltKeys.find(salt_proxy, fqdn)
+          key.delete unless key.nil?
         rescue Foreman::Exception => e
          Rails.logger.warn("Unable to delete key for #{fqdn}: #{e}")
         end


### PR DESCRIPTION
When deleting a host that was created without the plugin: undefifned `delete`
for nil at
/home/lzap/work/foreman_salt/app/models/foreman_salt/concerns/host_managed_extensions.rb:98:in
`delete_salt_key'