### PR TITLE
Fixes #12549 - Allow salt-proxy and salt_environment to be mass-assigned

### DIFF
--- a/app/models/foreman_salt/concerns/host_managed_extensions.rb
+++ b/app/models/foreman_salt/concerns/host_managed_extensions.rb
@@ -24,6 +24,9 @@ module ForemanSalt
         after_build      :delete_salt_key, :if => ->(host) { host.salt_proxy }
         before_provision :accept_salt_key, :if => ->(host) { host.salt_proxy }
         before_destroy   :delete_salt_key, :if => ->(host) { host.salt_proxy }
+
+        attr_accessible :salt_proxy_id, :salt_proxy_name, :salt_environment_id,
+          :salt_environment_name
       end
 
       def configuration_with_salt?

--- a/app/models/foreman_salt/concerns/hostgroup_extensions.rb
+++ b/app/models/foreman_salt/concerns/hostgroup_extensions.rb
@@ -13,6 +13,9 @@ module ForemanSalt
         scoped_search :in => :salt_modules, :on => :name, :complete_value => true, :rename => :salt_state
         scoped_search :in => :salt_environment, :on => :name, :complete_value => true, :rename => :salt_environment
         scoped_search :in => :salt_proxy, :on => :name, :complete_value => true, :rename => :saltmaster
+
+        attr_accessible :salt_proxy_id, :salt_proxy_name, :salt_environment_id,
+          :salt_environment_name
       end
 
       def all_salt_modules


### PR DESCRIPTION
As part of projects.theforeman.org/projects/foreman/issues/7568 , the
Host and Hostgroup models will become mass-assignment protected.
In that case, we have to whitelist the attributes that come from
Salt that are mass assigned. A few tests use it and will fail
otherwise.