### PR TITLE
Convert duration from milliseconds to seconds

### DIFF
--- a/app/services/foreman_salt/report_importer.rb
+++ b/app/services/foreman_salt/report_importer.rb
@@ -114,6 +114,10 @@ module ForemanSalt
                    else
                      result['duration']
                    end
+        # Convert duration from milliseconds to seconds
+        if duration.is_a? Float
+          duration = duration / 1000
+        end
 
         time[resource] = duration || 0
       end


### PR DESCRIPTION
Currently, there is an inconsistency in runtime units on Foreman reports. Foreman is expecting the runtime to be in _seconds_, while Salt reports runtime in _milliseconds_.

This is a change as a result of the discussion here:
https://github.com/theforeman/smart_proxy_salt/pull/15