### PR TITLE
Additional arguments for salt invocation

### DIFF
--- a/app/lib/proxy_api/salt.rb
+++ b/app/lib/proxy_api/salt.rb
@@ -69,12 +69,8 @@ module ::ProxyAPI
       raise ProxyException.new(url, e, N_('Unable to delete Salt key for %s'), name)
     end
 
-    def highstate(name, env, states)
-      payload = {
-        :saltenv => env,
-        :states => states
-      }
-      parse(post(JSON.generate(payload), "highstate/#{name}"))
+    def highstate(name, args)
+      parse(post(JSON.generate(args), "highstate/#{name}"))
     rescue => e
       raise ProxyException.new(url, e, N_('Unable to run Salt state.highstate for %s'), name)
     end

--- a/app/lib/proxy_api/salt.rb
+++ b/app/lib/proxy_api/salt.rb
@@ -69,8 +69,12 @@ module ::ProxyAPI
       raise ProxyException.new(url, e, N_('Unable to delete Salt key for %s'), name)
     end
 
-    def highstate(name)
-      parse(post('', "highstate/#{name}"))
+    def highstate(name, env, states)
+      payload = {
+        :saltenv => env,
+        :states => states
+      }
+      parse(post(JSON.generate(payload), "highstate/#{name}"))
     rescue => e
       raise ProxyException.new(url, e, N_('Unable to run Salt state.highstate for %s'), name)
     end

--- a/app/models/foreman_salt/concerns/host_managed_extensions.rb
+++ b/app/models/foreman_salt/concerns/host_managed_extensions.rb
@@ -52,7 +52,9 @@ module ForemanSalt
           logger.warn 'Unable to execute salt run, no salt proxies defined'
           return false
         end
-        ProxyAPI::Salt.new(:url => salt_proxy.url).highstate name
+        env = salt_environment ? salt_environment : "base"
+        states = salt_modules_for_enc
+        ProxyAPI::Salt.new(:url => salt_proxy.url).highstate(name, env, states)
       rescue => e
         errors.add(:base, _('Failed to execute state.highstate: %s') % e)
         false

--- a/app/models/foreman_salt/concerns/host_managed_extensions.rb
+++ b/app/models/foreman_salt/concerns/host_managed_extensions.rb
@@ -52,9 +52,11 @@ module ForemanSalt
           logger.warn 'Unable to execute salt run, no salt proxies defined'
           return false
         end
-        env = salt_environment ? salt_environment : "base"
-        states = salt_modules_for_enc
-        ProxyAPI::Salt.new(:url => salt_proxy.url).highstate(name, env, states)
+        salt_args = {
+          :saltenv => salt_environment ? salt_environment : Setting[:salt_default_saltenv],
+          :states => salt_modules_for_enc
+        }
+        ProxyAPI::Salt.new(:url => salt_proxy.url).highstate(name, salt_args)
       rescue => e
         errors.add(:base, _('Failed to execute state.highstate: %s') % e)
         false

--- a/app/models/setting/salt.rb
+++ b/app/models/setting/salt.rb
@@ -4,7 +4,8 @@ class Setting::Salt < Setting
 
     transaction do
       [
-        set('salt_namespace_pillars', N_("Namespace Foreman pillars under 'foreman' key"), false)
+        set('salt_namespace_pillars', N_("Namespace Foreman pillars under 'foreman' key"), false),
+        set('salt_default_saltenv', N_("Default saltenv variable value"), "base")
       ].each { |s| self.create! s.update(:category => 'Setting::Salt') }
     end
     true


### PR DESCRIPTION
Adding ability to pass arguments for salt invocation.
Currently only the information about the target host is passed to smart-proxy.
Thus only `salt <name> state.highstate` may be run which is insufficient, limiting and inconsistent with whichever salt environment was picked in GUI (as this environment is not passed to highstate invocation).
This PR introduces arguments built as hash and passed as http payload to smart-proxy.
Hash includes state list and saltenv (both already selectable in GUI)
It can be further extended with more salt args (especially _test_ but it will require GUI changes)
