### PR TITLE
fixes #21523 - replace alias_method_chain with Module.prepend

### DIFF
--- a/app/controllers/foreman_salt/concerns/hostgroups_controller_extensions.rb
+++ b/app/controllers/foreman_salt/concerns/hostgroups_controller_extensions.rb
@@ -3,8 +3,25 @@ module ForemanSalt
     module HostgroupsControllerExtensions
       extend ActiveSupport::Concern
 
+      module Overrides
+        def load_vars_for_ajax
+          super
+          @obj = @hostgroup
+          @salt_environment ||= @hostgroup.salt_environment
+
+          if @salt_environment
+            @inherited_salt_modules = @salt_environment.salt_modules.where(:id => @hostgroup.inherited_salt_modules)
+            @salt_modules           = @salt_environment.salt_modules - @inherited_salt_modules
+          else
+            @inherited_salt_modules = @salt_modules = []
+          end
+
+          @selected = @hostgroup.salt_modules || []
+        end
+      end
+
       included do
-        alias_method_chain :load_vars_for_ajax, :salt_modules
+        prepend Overrides
       end
 
       def salt_environment_selected
@@ -17,23 +34,6 @@ module ForemanSalt
         else
           logger.info 'environment_id is required to render states'
         end
-      end
-
-      private
-
-      def load_vars_for_ajax_with_salt_modules
-        load_vars_for_ajax_without_salt_modules
-        @obj = @hostgroup
-        @salt_environment ||= @hostgroup.salt_environment
-
-        if @salt_environment
-          @inherited_salt_modules = @salt_environment.salt_modules.where(:id => @hostgroup.inherited_salt_modules)
-          @salt_modules           = @salt_environment.salt_modules - @inherited_salt_modules
-        else
-          @inherited_salt_modules = @salt_modules = []
-        end
-
-        @selected = @hostgroup.salt_modules || []
       end
     end
   end

--- a/app/controllers/foreman_salt/concerns/hosts_controller_extensions.rb
+++ b/app/controllers/foreman_salt/concerns/hosts_controller_extensions.rb
@@ -3,31 +3,32 @@ module ForemanSalt
     module HostsControllerExtensions
       extend ActiveSupport::Concern
 
+      module Overrides
+        def process_hostgroup
+          @hostgroup = Hostgroup.find(params[:host][:hostgroup_id]) if params[:host][:hostgroup_id].to_i > 0
+          return head(:not_found) unless @hostgroup
+
+          @salt_modules           = @host.salt_modules if @host
+          @salt_environment       = @host.salt_environment if @host
+          @inherited_salt_modules = @hostgroup.all_salt_modules
+          super
+        end
+
+        private
+
+        def load_vars_for_ajax
+          return unless @host
+          @obj                    = @host
+          @salt_environment       = @host.salt_environment if @host
+          @selected               = @host.salt_modules
+          @salt_modules           = @host.salt_environment ? @salt_environment.salt_modules : []
+          @inherited_salt_modules = @host.hostgroup.all_salt_modules if @host.hostgroup
+          super
+        end
+      end
+
       included do
-        alias_method_chain :load_vars_for_ajax, :salt_modules
-        alias_method_chain :process_hostgroup, :salt_modules
-      end
-
-      def process_hostgroup_with_salt_modules
-        @hostgroup = Hostgroup.find(params[:host][:hostgroup_id]) if params[:host][:hostgroup_id].to_i > 0
-        return head(:not_found) unless @hostgroup
-
-        @salt_modules           = @host.salt_modules if @host
-        @salt_environment       = @host.salt_environment if @host
-        @inherited_salt_modules = @hostgroup.all_salt_modules
-        process_hostgroup_without_salt_modules
-      end
-
-      private
-
-      def load_vars_for_ajax_with_salt_modules
-        return unless @host
-        @obj                    = @host
-        @salt_environment       = @host.salt_environment if @host
-        @selected               = @host.salt_modules
-        @salt_modules           = @host.salt_environment ? @salt_environment.salt_modules : []
-        @inherited_salt_modules = @host.hostgroup.all_salt_modules if @host.hostgroup
-        load_vars_for_ajax_without_salt_modules
+        prepend Overrides
       end
     end
   end

--- a/app/helpers/concerns/foreman_salt/hosts_helper_extensions.rb
+++ b/app/helpers/concerns/foreman_salt/hosts_helper_extensions.rb
@@ -2,37 +2,37 @@ module ForemanSalt
   module HostsHelperExtensions
     extend ActiveSupport::Concern
 
-    included do
-      alias_method_chain :host_title_actions, :salt
-      alias_method_chain :show_appropriate_host_buttons, :salt
-      alias_method_chain :overview_fields, :salt
-    end
-
-    def show_appropriate_host_buttons_with_salt(host)
-      (show_appropriate_host_buttons_without_salt(host) +
+    module Overrides
+      def show_appropriate_host_buttons(host)
+        (super(host) +
          [(link_to_if_authorized(_('Salt ENC'), { :controller => :'foreman_salt/minions', :action => :node, :id => host },
                                  :title => _('Salt external nodes YAML dump'), :class => 'btn btn-default') unless host.salt_master.blank?)]).flatten.compact
-    end
+      end
 
-    def host_title_actions_with_salt(host)
-      title_actions(
-        button_group(
-          if host.try(:salt_proxy)
-            link_to_if_authorized(_('Run Salt'), { :controller => :'foreman_salt/minions', :action => :run, :id => host },
-                                  :title => _('Trigger a state.highstate run on a node'), :class => 'btn btn-primary')
+      def host_title_actions(host)
+        title_actions(
+          button_group(
+            if host.try(:salt_proxy)
+              link_to_if_authorized(_('Run Salt'), { :controller => :'foreman_salt/minions', :action => :run, :id => host },
+                                    :title => _('Trigger a state.highstate run on a node'), :class => 'btn btn-primary')
           end
+          )
         )
-      )
-      host_title_actions_without_salt(host)
+        super(host)
+      end
+
+      def overview_fields(host)
+        fields = super(host)
+
+        fields.insert(5, [_('Salt Master'), (link_to(host.salt_proxy, hosts_path(:search => "saltmaster = #{host.salt_proxy}")) if host.salt_proxy)])
+        fields.insert(6, [_('Salt Environment'), (link_to(host.salt_environment, hosts_path(:search => "salt_environment = #{host.salt_environment}")) if host.salt_environment)])
+
+        fields
+      end
     end
 
-    def overview_fields_with_salt(host)
-      fields = overview_fields_without_salt(host)
-
-      fields.insert(5, [_('Salt Master'), (link_to(host.salt_proxy, hosts_path(:search => "saltmaster = #{host.salt_proxy}")) if host.salt_proxy)])
-      fields.insert(6, [_('Salt Environment'), (link_to(host.salt_environment, hosts_path(:search => "salt_environment = #{host.salt_environment}")) if host.salt_environment)])
-
-      fields
+    included do
+      prepend Overrides
     end
   end
 end

--- a/app/helpers/concerns/foreman_salt/smart_proxies_helper_extensions.rb
+++ b/app/helpers/concerns/foreman_salt/smart_proxies_helper_extensions.rb
@@ -2,19 +2,21 @@ module ForemanSalt
   module SmartProxiesHelperExtensions
     extend ActiveSupport::Concern
 
-    included do
-      alias_method_chain :proxy_actions, :salt_proxy
+    module Overrides
+      def proxy_actions(proxy, authorizer)
+        actions = super
+
+        if proxy.has_feature?('Salt')
+          actions << display_link_if_authorized(_('Salt Keys'), :controller => 'foreman_salt/salt_keys', :action => 'index', :smart_proxy_id => proxy)
+          actions << display_link_if_authorized(_('Salt Autosign'), :controller => 'foreman_salt/salt_autosign', :action => 'index', :smart_proxy_id => proxy)
+        end
+
+        actions
+      end
     end
 
-    def proxy_actions_with_salt_proxy(proxy, authorizer)
-      actions = proxy_actions_without_salt_proxy(proxy, authorizer)
-
-      if proxy.has_feature?('Salt')
-        actions << display_link_if_authorized(_('Salt Keys'), :controller => 'foreman_salt/salt_keys', :action => 'index', :smart_proxy_id => proxy)
-        actions << display_link_if_authorized(_('Salt Autosign'), :controller => 'foreman_salt/salt_autosign', :action => 'index', :smart_proxy_id => proxy)
-      end
-
-      actions
+    included do
+      prepend Overrides
     end
   end
 end


### PR DESCRIPTION
This plugin conflicts with foreman_monitoring (see https://github.com/theforeman/foreman_monitoring/issues/30) because it still used `alias_method_chain`. This PR replaces the deprecated `alias_method_chain` with `Module.prepend`.