### PR TITLE
replace Setting::General.entries_per_page

### DIFF
--- a/app/controllers/foreman_salt/salt_autosign_controller.rb
+++ b/app/controllers/foreman_salt/salt_autosign_controller.rb
@@ -3,7 +3,7 @@ module ForemanSalt
     def index
       setup
       autosign = @api.autosign_list
-      @autosign = autosign.paginate :page => params[:page], :per_page => Setting::General.entries_per_page
+      @autosign = autosign.paginate :page => params[:page], :per_page => Setting[:entries_per_page]
     end
 
     def new

--- a/app/controllers/foreman_salt/salt_keys_controller.rb
+++ b/app/controllers/foreman_salt/salt_keys_controller.rb
@@ -9,7 +9,7 @@ module ForemanSalt
              else
                SmartProxies::SaltKeys.find_by_state @proxy, params[:state].downcase
              end
-      @keys = keys.sort.paginate :page => params[:page], :per_page => Setting::General.entries_per_page
+      @keys = keys.sort.paginate :page => params[:page], :per_page => Setting[:entries_per_page]
     end
 
     def accept


### PR DESCRIPTION
Replaced `Setting::General.entries_per_page` with `Setting[:entries_per_page]` to fix 
> Oops, we're sorry but something went wrong undefined method `entries_per_page' for #<Class:0x0000000935b638>

error message when trying to access "Salt Keys" and "Salt Autosign" functions in frontend.