### PR TITLE
remove unnecessary fails for salt_keys - fixes #21772

### DIFF
--- a/app/services/foreman_salt/smart_proxies/salt_keys.rb
+++ b/app/services/foreman_salt/smart_proxies/salt_keys.rb
@@ -31,14 +31,12 @@ module ForemanSalt
     end
 
     def accept
-      fail ::Foreman::Exception.new(N_('unable to re-accept an accepted key')) unless state == 'unaccepted'
       proxy = SmartProxy.find(smart_proxy_id)
       Rails.cache.delete("saltkeys_#{proxy.id}") if Rails.env.production?
       ProxyAPI::Salt.new(:url => proxy.url).key_accept name
     end
 
     def reject
-      fail ::Foreman::Exception.new(N_('unable to reject an accepted key')) unless state == 'unaccepted'
       proxy = SmartProxy.find(smart_proxy_id)
       Rails.cache.delete("saltkeys_#{proxy.id}") if Rails.env.production?
       ProxyAPI::Salt.new(:url => proxy.url).key_reject name


### PR DESCRIPTION
for whatever reasons the accept and reject salt_key functions did raise errors while the delete function did not raise anything. once https://github.com/theforeman/smart_proxy_salt/pull/29 has been merged there is no need to check this anymore as accepting + rejecting keys will work in any combination.