### PR TITLE
12399 foreman salt processes ipv6 as ipv4 addresses

### DIFF
--- a/app/services/foreman_salt/fact_parser.rb
+++ b/app/services/foreman_salt/fact_parser.rb
@@ -85,7 +85,7 @@ module ForemanSalt
       if name == 'CentOS'
         if sub
           minor += '.' + sub
-          end
+        end
       end
       { :name => name, :major => major, :minor => minor }
     end

--- a/app/services/foreman_salt/fact_parser.rb
+++ b/app/services/foreman_salt/fact_parser.rb
@@ -56,17 +56,17 @@ module ForemanSalt
 
       facts.each do |fact, value|
         next unless value && fact.to_s =~ /^ip_interfaces/
-        (_, interface, number) = fact.split(FactName::SEPARATOR)
+        (_, interface_name, _) = fact.split(FactName::SEPARATOR)
 
-        interface_name = if number == '0' || number.nil?
-                           interface
-                         else
-                           "#{interface}.#{number}"
-                         end
-
-        if !interface.blank? && interface != 'lo'
-          interfaces[interface_name] = {} if interfaces[interface_name].blank?
-          interfaces[interface_name].merge!(:ipaddress => value, :macaddress => macs[interface])
+        if !interface_name.blank? && interface_name != 'lo'
+          interface = interfaces.fetch(interface_name, {})
+          interface[:macaddress] = macs[interface_name]
+          if Net::Validations::validate_ip6(value)
+            interface[:ipaddress6] = value
+          else
+            interface[:ipaddress] = value
+          end
+          interfaces[interface_name] = interface
         end
       end
 


### PR DESCRIPTION
The foreman salt plugin retrieved the following facts from which it processed the ip addresses:
```
ip_interfaces::eth3.128::0 => "192.168.128.3"
ip_interfaces::eth3.128::1 => "fe80::5054:ff:fea0:ffc4"
```
The second entry resulted in an interface name 'eth3.1', which seem to be the cause of issue https://projects.theforeman.org/issues/12399
As foreman then tries to parse an the address, it receives an IPv6 address where it expects and IPv4 address. First of all this results in a warning that the IP address is invalid. Second of all, because of this, IPv6 addresses are not shown in the foreman web interface.

This pull request should fix that.

One side node is that currently the key 'ip_interfaces' is used to process the IP addresses. Salt also seems to send the keys 'ip4_interfaces' and 'ip6_interfaces'. Using those keys might be another approach to solve the problem.

Issue was also discovered here: https://community.theforeman.org/t/detection-of-changes-in-host-network-configuration-by-foreman/10039/30