### PR TITLE
fixes error triggerd by deprecated notice flash type.

### DIFF
--- a/app/controllers/foreman_salt/minions_controller.rb
+++ b/app/controllers/foreman_salt/minions_controller.rb
@@ -26,7 +26,7 @@ module ForemanSalt
 
     def run
       if @minion.saltrun!
-        notice _('Successfully executed, check log files for more details')
+        success _('Successfully executed, check log files for more details')
       else
         error @minion.errors[:base].to_sentence
       end

--- a/app/controllers/foreman_salt/salt_environments_controller.rb
+++ b/app/controllers/foreman_salt/salt_environments_controller.rb
@@ -27,7 +27,7 @@ module ForemanSalt
 
     def update
       if @salt_environment.update_attributes(salt_environment_params)
-        notice _('Successfully updated %s.' % @salt_environment.to_s)
+        success _('Successfully updated %s.' % @salt_environment.to_s)
         redirect_to salt_environments_path
       else
         process_error

--- a/app/controllers/foreman_salt/salt_modules_controller.rb
+++ b/app/controllers/foreman_salt/salt_modules_controller.rb
@@ -31,7 +31,7 @@ module ForemanSalt
 
     def update
       if @salt_module.update_attributes(salt_module_params)
-        notice _('Successfully updated %s.' % @salt_module.to_s)
+        success _('Successfully updated %s.' % @salt_module.to_s)
         redirect_to salt_modules_path
       else
         process_error
@@ -63,14 +63,14 @@ module ForemanSalt
       @deletes = result[:deletes]
 
       if @changes.empty?
-        notice _('No changes found')
+        info _('No changes found')
         redirect_to salt_modules_path
       end
     end
 
     def apply_changes
       if params[:changed].blank?
-        notice _('No changes found')
+        info _('No changes found')
       else
         params[:changed].each do |environment, states|
           next unless states[:add] || states[:remove]
@@ -80,7 +80,7 @@ module ForemanSalt
         end
 
         clean_orphans
-        notice _('Successfully imported')
+        success _('Successfully imported')
       end
       redirect_to salt_modules_path
     end

--- a/app/services/foreman_salt/report_importer.rb
+++ b/app/services/foreman_salt/report_importer.rb
@@ -65,7 +65,7 @@ module ForemanSalt
                   :err
                 else
                   # nil mean "unchanged" when running highstate with test=True
-                  :notice
+                  :info
                 end
 
         source = Source.find_or_create(resource)


### PR DESCRIPTION
Based on: https://community.theforeman.org/t/foreman-salt-run-salt-via-foreman-webinterface-oops-were-sorry-but-something-went-wrong/12281

> The notice flash type has been deprecated in Foreman 1.18 and removed in Foreman 1.20.

Fixes error “Oops, we’re sorry but something went wrong wrong number of arguments (given 1, expected 0)” when pressing on "run salt" in foreman 1.20

Updated _notice_ to _info_ or _success_ flash messages.