### PR TITLE
Show Salt Actions in Smart Proxy

### DIFF
--- a/app/helpers/concerns/foreman_salt/smart_proxies_helper_extensions.rb
+++ b/app/helpers/concerns/foreman_salt/smart_proxies_helper_extensions.rb
@@ -3,7 +3,7 @@ module ForemanSalt
     extend ActiveSupport::Concern
 
     module Overrides
-      def proxy_actions(proxy, authorizer)
+      def feature_actions(proxy, authorizer)
         actions = super
 
         if proxy.has_feature?('Salt')

--- a/test/integration/salt_autosign_test.rb
+++ b/test/integration/salt_autosign_test.rb
@@ -15,6 +15,13 @@ module ForemanSalt
       assert_row_button(smart_proxies_path, @proxy.name, 'Salt Autosign', true)
     end
 
+    test 'smart proxy details has autosign link' do
+      visit smart_proxy_path(@proxy)
+      assert page.has_link? "Salt Autosign"
+      click_link "Salt Autosign"
+      assert page.has_content?("Autosign entries for #{@proxy.hostname}"), 'Page title does not appear'
+    end
+
     test 'index page' do
       visit smart_proxy_salt_autosign_index_path(:smart_proxy_id => @proxy.id)
       assert find_link('Keys').visible?, 'Keys is not visible'

--- a/test/integration/salt_keys_test.rb
+++ b/test/integration/salt_keys_test.rb
@@ -18,6 +18,13 @@ module ForemanSalt
       assert_row_button(smart_proxies_path, @proxy.name, 'Salt Keys', true)
     end
 
+    test 'smart proxy details has keys link' do
+      visit smart_proxy_path(@proxy)
+      assert page.has_link? "Salt Keys"
+      click_link "Salt Keys"
+      assert page.has_content?("Salt Keys on #{@proxy.hostname}"), 'Page title does not appear'
+    end
+
     test 'index page' do
       visit smart_proxy_salt_keys_path(:smart_proxy_id => @proxy.id)
       assert find_link('Autosign').visible?, 'Autosign is not visible'


### PR DESCRIPTION
Salt Keys and Salt Autosign should be displayed
- in Infrastructure -> Smart Proxy
- in Infrastructure -> Smart Proxy -> Proxy