### PR TITLE
Fix report_importer so pending changes are again tagged as notice so …

### DIFF
--- a/app/services/foreman_salt/report_importer.rb
+++ b/app/services/foreman_salt/report_importer.rb
@@ -65,7 +65,7 @@ module ForemanSalt
                   :err
                 else
                   # nil mean "unchanged" when running highstate with test=True
-                  :info
+                  :notice
                 end
 
         source = Source.find_or_create(resource)


### PR DESCRIPTION
Fix report_importer so pending changes are again tagged as notice so we can recognise them again.

In pull request 83 i changed one to many "notice" occurence to "info". 
This marked marked pending changes as "info" instead of a blue "notice" level.

My apologies.