### PR TITLE
highstate uploader fails if pchanges doesn't have a diff

### DIFF
--- a/app/services/foreman_salt/report_importer.rb
+++ b/app/services/foreman_salt/report_importer.rb
@@ -77,7 +77,7 @@ module ForemanSalt
 
         message = if result['changes']['diff']
                     result['changes']['diff']
-                  elsif !result['pchanges'].blank? && result['pchanges']['diff']
+                  elsif !result['pchanges'].blank? && result['pchanges'].include?('diff')
                     result['pchanges']['diff']
                   elsif !result['comment'].blank?
                     result['comment']


### PR DESCRIPTION
Highstate upload fails if there is no diff in pchanges. For example if there is a `file.managed` without a valid source file the following pchanges result (`result['pchanges']`) is available:
`[false, "Source file salt://mytest/files/example.jinja not found in saltenv 'test'"]`

Before the patch there was en Exception thrown, because there was no diff inside the list.