### PR TITLE
Allow foreman-tasks 1.0.0

### DIFF
--- a/foreman_salt.gemspec
+++ b/foreman_salt.gemspec
@@ -14,7 +14,7 @@ Gem::Specification.new do |s|
   s.test_files = Dir['test/**/*']
 
   s.add_dependency 'deface', '< 2.0'
-  s.add_dependency 'foreman-tasks', '~> 0.8'
+  s.add_dependency 'foreman-tasks', '>= 0.8'
   s.add_dependency 'foreman_remote_execution', '~> 2.0.0'
   s.add_development_dependency 'rubocop', '~> 0.71.0'
 end


### PR DESCRIPTION
foreman-tasks 1.0.0 is not any revolution and only updated vendor to v3, meaning it requires Foreman 1.25, that's the reason for major bump. We may see that more often, so I suggest we drop the major version up limitation.