### PR TITLE
Use autosign_grains/foreman_provisioning_serial

### DIFF
--- a/app/lib/proxy_api/salt.rb
+++ b/app/lib/proxy_api/salt.rb
@@ -14,7 +14,7 @@ module ::ProxyAPI
     def autosign_create(name)
       parse(post('', "autosign/#{URI.escape(name)}"))
     rescue => e
-      raise ProxyException.new(url, e, N_('Unable to set Salt autosign for %s'), name)
+      raise ProxyException.new(url, e, N_('Unable to set Salt autosign hostname for %s'), name)
     end
 
     def autosign_remove(name)
@@ -22,7 +22,21 @@ module ::ProxyAPI
     rescue RestClient::ResourceNotFound
       true # entry doesn't exists anyway
     rescue => e
-      raise ProxyException.new(url, e, N_('Unable to delete Salt autosign for %s'), name)
+      raise ProxyException.new(url, e, N_('Unable to delete Salt autosign hostname for %s'), name)
+    end
+
+    def autosign_create_key(key)
+      parse(post('', "autosign_key/#{URI.escape(key)}"))
+    rescue => e
+      raise ProxyException.new(url, e, N_('Unable to create Salt autosign key %s'), key)
+    end
+
+    def autosign_remove_key(key)
+      parse(delete("autosign_key/#{URI.escape(key)}"))
+    rescue RestClient::ResourceNotFound
+      true # entry doesn't exists anyway
+    rescue => e
+      raise ProxyException.new(url, e, N_('Unable to delete Salt autosign key %s'), key)
     end
 
     def environments_list

--- a/app/models/foreman_salt/salt_status.rb
+++ b/app/models/foreman_salt/salt_status.rb
@@ -1,0 +1,12 @@
+module ForemanSalt
+  # Define the class that holds different states a Salt host become
+  class SaltStatus
+    def self.minion_auth_waiting
+      'Waiting for Salt Minion to authenticate'
+    end
+
+    def self.minion_auth_success
+      'Salt Minion was authenticated successfully to Salt Master'
+    end
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -38,6 +38,7 @@ Rails.application.routes.draw do
       scope '(:apiv)', :defaults => { :apiv => 'v2' },
                        :apiv => /v1|v2/, :constraints => ApiConstraints.new(:version => 2) do
         match '/jobs/upload' => 'foreman_salt/api/v2/jobs#upload', :via => :post
+        match '/salt_autosign_auth' => 'foreman_salt/api/v2/salt_autosign#auth', :via => :put
 
         constraints(:smart_proxy_id => /[\w\.-]+/, :name => /[\w\.-]+/, :record => /[^\/]+/) do
           match '/salt_keys/:smart_proxy_id' => 'foreman_salt/api/v2/salt_keys#index', :via => :get

--- a/db/migrate/20210312150333_add_salt_autosign_to_host.rb
+++ b/db/migrate/20210312150333_add_salt_autosign_to_host.rb
@@ -1,0 +1,6 @@
+class AddSaltAutosignToHost < ActiveRecord::Migration[4.2]
+  def change
+    add_column :hosts, :salt_autosign_key, :string, limit: 255, null: true
+    add_column :hosts, :salt_status, :string, limit: 255, null: true
+  end
+end

--- a/test/functional/api/v2/salt_autosign_controller_test.rb
+++ b/test/functional/api/v2/salt_autosign_controller_test.rb
@@ -3,6 +3,8 @@ require 'test_plugin_helper'
 class ::ForemanSalt::Api::V2::SaltAutosignControllerTest < ActionController::TestCase
   setup do
     @proxy = FactoryBot.create(:smart_proxy, :with_salt_feature)
+    @host = FactoryBot.create(:host, :managed)
+    @host.salt_proxy = @proxy
     ProxyAPI::Salt.any_instance.stubs(:autosign_list).returns((%w(foo bar baz)))
   end
 

--- a/test/integration/salt_autosign_test.rb
+++ b/test/integration/salt_autosign_test.rb
@@ -19,13 +19,13 @@ module ForemanSalt
       visit smart_proxy_path(@proxy)
       assert page.has_link? "Salt Autosign"
       click_link "Salt Autosign"
-      assert page.has_content?("Autosign entries for #{@proxy.hostname}"), 'Page title does not appear'
+      assert page.has_title?("Autosign entries for #{@proxy.hostname}"), 'Page title does not appear'
     end
 
     test 'index page' do
       visit smart_proxy_salt_autosign_index_path(:smart_proxy_id => @proxy.id)
       assert find_link('Keys').visible?, 'Keys is not visible'
-      assert has_content?("Autosign entries for #{@proxy.hostname}"), 'Page title does not appear'
+      assert has_title?("Autosign entries for #{@proxy.hostname}"), 'Page title does not appear'
       assert has_content?('Displaying'), 'Pagination "Display ..." does not appear'
     end
 

--- a/test/integration/salt_keys_test.rb
+++ b/test/integration/salt_keys_test.rb
@@ -22,13 +22,12 @@ module ForemanSalt
       visit smart_proxy_path(@proxy)
       assert page.has_link? "Salt Keys"
       click_link "Salt Keys"
-      assert page.has_content?("Salt Keys on #{@proxy.hostname}"), 'Page title does not appear'
+      assert page.has_title?("Salt Keys on #{@proxy}"), 'Page title does not appear'
     end
 
     test 'index page' do
       visit smart_proxy_salt_keys_path(:smart_proxy_id => @proxy.id)
-      assert find_link('Autosign').visible?, 'Autosign is not visible'
-      assert has_content?("Salt Keys on #{@proxy.hostname}"), 'Page title does not appear'
+      assert has_title?("Salt Keys on #{@proxy}"), 'Page title does not appear'
       assert has_content?('Displaying'), 'Pagination "Display ..." does not appear'
     end
 


### PR DESCRIPTION
Implement [Autosign via Grains](https://docs.saltproject.io/en/latest/topics/tutorials/autoaccept_grains.html) procedure instead of `autosign.conf` for authentication. For detailed information about the process, have a look at the [Foreman Community Demo #92](https://youtu.be/65yWyKxCEoU?t=3027). This PR refers to the following [Smart Proxy Salt PR](https://github.com/theforeman/smart_proxy_salt/pull/58) and [Foreman PR](https://github.com/theforeman/foreman/pull/8489).
* Remove previous `autosign.conf` procedure
* Add columns to hosts table
  * `salt_autosign_key` to store the autosign key
  * `salt_status` to give information about the current minion status 
* Generate autosign key during host creation
* Send autosign key to the corresponding Smart Proxy
* Provide function `derive_salt_grains` for the provisioning template to transfer the autosign key onto the host
* Add StatusController to trigger the autosign delete process when the newly deployed host was authenticated successfully by the Smart Proxy
