### PR TITLE
Enable higher Rubocop version

### DIFF
--- a/foreman_salt.gemspec
+++ b/foreman_salt.gemspec
@@ -16,5 +16,5 @@ Gem::Specification.new do |s|
   s.add_dependency 'deface', '< 2.0'
   s.add_dependency 'foreman-tasks', '>= 0.8'
   s.add_dependency 'foreman_remote_execution', '>= 2.0.0'
-  s.add_development_dependency 'rubocop', '~> 0.71.0'
+  s.add_development_dependency 'rubocop', '>= 0.71.0'
 end


### PR DESCRIPTION
Rubocop was bound to `0.71.0` which does not work with the latest foreman.