### PR TITLE
WIP: refresh pillar data on host update

### DIFF
--- a/app/controllers/foreman_salt/concerns/hosts_controller_extensions.rb
+++ b/app/controllers/foreman_salt/concerns/hosts_controller_extensions.rb
@@ -63,6 +63,7 @@ module ForemanSalt
         @hosts.each do |host|
           host.salt_environment = ev
           host.save(:validate => false)
+          ProxyAPI::Salt.new(:url => salt_proxy.url).refresh_pillar host.name
         end
 
         success _('Updated hosts: changed salt environment')

--- a/app/lib/proxy_api/salt.rb
+++ b/app/lib/proxy_api/salt.rb
@@ -43,6 +43,12 @@ module ::ProxyAPI
       raise ProxyException.new(url, e, N_('Unable to fetch Salt states list'))
     end
 
+    def refresh_pillar(name)
+      parse(post('', "refresh_pillar/#{name}"))
+    rescue => e
+      raise ProxyException.new(url, e, N_('Unable to refresh pillar data for %s'), name)
+    end
+
     def key_list
       parse(get('key'))
     rescue => e

--- a/app/models/setting/salt.rb
+++ b/app/models/setting/salt.rb
@@ -2,7 +2,8 @@ class Setting::Salt < Setting
   def self.default_settings
     [
       set('salt_namespace_pillars', N_("Namespace Foreman pillars under 'foreman' key"), false),
-      set('salt_hide_run_salt_button', N_("Hide the Run Salt state.highstate button on the host details page"), false)
+      set('salt_hide_run_salt_button', N_("Hide the Run Salt state.highstate button on the host details page"), false),
+      set('salt_refresh_pillar_on_host_update', N_("Refresh the hosts pillar data if parameters were updated"), false)
     ]
   end
 


### PR DESCRIPTION
This PR is currently not finished and should not be merged. I want to start a discussion about how to integrate such a feature.
Our usecase:

We want to be able to use the Salt environment set in the hosts pillar data as the env for the minion. In order to do this we need
a little change in Salt (see https://github.com/saltstack/salt/pull/60233) and a new command in the proxy plugin (see https://github.com/theforeman/smart_proxy_salt/pull/65)

This works well, but now i hit a roadblock with the code in this PR. Because salt-master will run foreman-node (and therefor update the minions grains) it will trigger another host update, which in turn triggers a update of the hosts grains, resulting in an endless loop.
Is there any way to check whether the user has adjusted the Salt environment itself to only trigger the refresh of pillar data if that's the case?