### PR TITLE
operating system minor version cannot be nil

### DIFF
--- a/app/services/foreman_salt/fact_parser.rb
+++ b/app/services/foreman_salt/fact_parser.rb
@@ -89,7 +89,7 @@ module ForemanSalt
     def os_hash
       name = facts[:os]
       (_, major, minor, sub) = /(\d+)\.?(\d+)?\.?(\d+)?/.match(facts[:osrelease]).to_a
-      minor = minor.to_s if minor.nil?
+      minor = "" if minor.nil?
       if name == 'CentOS'
         if sub
           minor += '.' + sub

--- a/app/services/foreman_salt/fact_parser.rb
+++ b/app/services/foreman_salt/fact_parser.rb
@@ -89,6 +89,7 @@ module ForemanSalt
     def os_hash
       name = facts[:os]
       (_, major, minor, sub) = /(\d+)\.?(\d+)?\.?(\d+)?/.match(facts[:osrelease]).to_a
+      minor = minor.to_s if minor.nil?
       if name == 'CentOS'
         if sub
           minor += '.' + sub


### PR DESCRIPTION
Operating system minor version cannot be nil, because otherwise the operating system will not be set in foreman for those hosts. In our environment servers with Debian version 10 didn't get an operating system set as Debian operating system version is 10.

This is likely the same bug as been reported here for puppet: https://github.com/theforeman/foreman/pull/7632