### PR TITLE
Make Salt Master available for provisioning templates

### DIFF
--- a/app/models/foreman_salt/concerns/host_managed_extensions.rb
+++ b/app/models/foreman_salt/concerns/host_managed_extensions.rb
@@ -120,5 +120,5 @@ module ForemanSalt
 end
 
 class ::Host::Managed::Jail < Safemode::Jail
-  allow :salt_environment
+  allow :salt_environment, :salt_master
 end


### PR DESCRIPTION
In order to make the `@host.salt_master` available for provisioning templates, it has to be allowed in safe rendering mode.
This eliminates duplicate data like `@host.host_param('salt_master')`.