### PR TITLE
Fix error caused by wrong data type of host_params['salt_grains']

### DIFF
--- a/app/models/foreman_salt/concerns/host_managed_extensions.rb
+++ b/app/models/foreman_salt/concerns/host_managed_extensions.rb
@@ -107,7 +107,8 @@ module ForemanSalt
         begin
           Rails.logger.info("Derive Salt Grains from host_params and autosign_key")
           grains[autosign_grain_name] = salt_autosign_key if use_autosign && !salt_autosign_key.nil?
-          unless host_params[host_params_grains_name].nil?
+          unless host_params[host_params_grains_name].nil? ||
+              host_params[host_params_grains_name].class != Hash
             grains.merge!(host_params[host_params_grains_name])
           end
         rescue Foreman::Exception => e


### PR DESCRIPTION
* validate data type of host_params['salt_grains'] being a Hash in `derive_salt_grains`