### PR TITLE
Delete Salt Key on host deletion

### DIFF
--- a/app/models/foreman_salt/concerns/host_managed_extensions.rb
+++ b/app/models/foreman_salt/concerns/host_managed_extensions.rb
@@ -43,7 +43,7 @@ module ForemanSalt
         validate :salt_modules_in_host_environment
 
         after_build :ensure_salt_autosign, :if => ->(host) { host.salt_proxy }
-        before_destroy :remove_salt_autosign, :if => ->(host) { host.salt_proxy }
+        before_destroy :remove_salt_minion, :if => ->(host) { host.salt_proxy }
       end
 
       def salt_params
@@ -122,6 +122,17 @@ module ForemanSalt
       def ensure_salt_autosign
         remove_salt_autosign
         create_salt_autosign
+      end
+
+      def remove_salt_minion
+        remove_salt_autosign
+        remove_salt_key
+      end
+
+      def remove_salt_key
+        Rails.logger.info("Remove salt key for host #{fqdn}")
+        api = ProxyAPI::Salt.new(:url => salt_proxy.url)
+        api.key_delete(name)
       end
 
       def remove_salt_autosign


### PR DESCRIPTION
_Problem:_
When deleting a host which has an active salt-minion running, the corresponding Minion Salt Key is still accepted by the salt-master - even if the host was destroyed.

_Assumption:_
Salt Key should be deleted from _accepted salt keys_ when the host was destroyed.

_Fix:_
Modify `host_managed_extension` to delete Salt Key before host is destroyed