### PR TITLE
Add HostgroupController

### DIFF
--- a/app/controllers/foreman_salt/api/v2/salt_hostgroups_controller.rb
+++ b/app/controllers/foreman_salt/api/v2/salt_hostgroups_controller.rb
@@ -1,0 +1,42 @@
+module ForemanSalt
+  module Api
+    module V2
+      class SaltHostgroupsController < ::ForemanSalt::Api::V2::BaseController
+        include ::ForemanSalt::Concerns::SaltHostgroupParameters
+
+        before_action :find_resource
+
+        api :GET, '/hostgroups/:id', N_('Show the Salt parameters of a host group')
+        param :id, :identifier_dottable, required: true, desc: N_('ID of host group')
+        def show
+          @salt_hostgroup
+        end
+
+        def_param_group :salt_attributes do
+          param :hostgroup, Hash, required: true, action_aware: true do
+            param :salt_environment_id, :number, desc: N_('Salt environment ID')
+            param :salt_proxy_id, :number, desc: N_('Salt master/smart proxy ID')
+            param :salt_state_ids, Array, desc: N_('Array of Salt state IDs')
+          end
+        end
+
+        api :PUT, '/hostgroups/:id', N_('Update the Salt parameters of a host group')
+        param :id, :identifier_dottable, required: true, desc: N_('ID of host group')
+        param_group :salt_attributes
+        def update
+          params.extract!(:salt_hostgroup) if params[:salt_hostgroup]
+          params[:hostgroup][:salt_module_ids] = params[:hostgroup].delete(:salt_state_ids) if params[:hostgroup][:salt_state_ids]
+          process_response @salt_hostgroup.update(salt_hostgroup_params)
+        end
+
+        def controller_permission
+          'hostgroups'
+        end
+
+        def resource_class
+          Hostgroup
+        end
+      end
+    end
+  end
+end

--- a/app/controllers/foreman_salt/concerns/salt_hostgroup_parameters.rb
+++ b/app/controllers/foreman_salt/concerns/salt_hostgroup_parameters.rb
@@ -1,0 +1,25 @@
+module ForemanSalt
+  module Concerns
+    module SaltHostgroupParameters
+      extend ActiveSupport::Concern
+      include Foreman::Controller::Parameters::LookupKey
+
+      class_methods do
+        def salt_hostgroup_params_filter
+          Foreman::ParameterFilter.new(Hostgroup).tap do |filter|
+            filter.permit hostgroup: [:salt_environment_id, :salt_proxy_id, { salt_module_ids: [] }]
+            filter.permit_by_context :required, nested: true
+            filter.permit_by_context :id, ui: false, api: true, nested: true
+
+            add_lookup_key_params_filter(filter)
+          end
+        end
+      end
+
+      def salt_hostgroup_params
+        param_name = parameter_filter_context.api? ? 'hostgroup' : 'foreman_salt_salt_hostgroup'
+        self.class.salt_hostgroup_params_filter.filter_params(params, parameter_filter_context, param_name)
+      end
+    end
+  end
+end

--- a/app/models/foreman_salt/concerns/hostgroup_extensions.rb
+++ b/app/models/foreman_salt/concerns/hostgroup_extensions.rb
@@ -13,6 +13,9 @@ module ForemanSalt
         scoped_search relation: :salt_modules, on: :name, complete_value: true, rename: :salt_state
         scoped_search relation: :salt_environment, on: :name, complete_value: true, rename: :salt_environment
         scoped_search relation: :salt_proxy, on: :name, complete_value: true, rename: :saltmaster
+
+        validates :salt_proxy, presence: true, unless: -> { salt_proxy_id.blank? }
+        validates :salt_environment, presence: true, unless: -> { salt_environment_id.blank? }
       end
 
       def all_salt_modules

--- a/app/views/foreman_salt/api/v2/salt_hostgroups/base.json.rabl
+++ b/app/views/foreman_salt/api/v2/salt_hostgroups/base.json.rabl
@@ -1,0 +1,7 @@
+object @salt_hostgroup
+
+attributes :id, :name, :salt_master, :salt_environment
+
+child salt_modules: :salt_states do
+  extends 'foreman_salt/api/v2/salt_states/base'
+end

--- a/app/views/foreman_salt/api/v2/salt_hostgroups/show.json.rabl
+++ b/app/views/foreman_salt/api/v2/salt_hostgroups/show.json.rabl
@@ -1,0 +1,3 @@
+object @salt_hostgroup
+
+extends 'foreman_salt/api/v2/salt_hostgroups/base'

--- a/app/views/foreman_salt/api/v2/salt_hostgroups/update.json.rabl
+++ b/app/views/foreman_salt/api/v2/salt_hostgroups/update.json.rabl
@@ -1,0 +1,3 @@
+object @salt_hostgroup
+
+extends 'foreman_salt/api/v2/salt_hostgroups/base'

--- a/config/api_routes.rb
+++ b/config/api_routes.rb
@@ -21,6 +21,7 @@ Rails.application.routes.draw do
           resources :salt_environments, only: %i[show index create destroy], controller: '/foreman_salt/api/v2/salt_environments'
           resources :salt_minions, only: %i[show index update], controller: '/foreman_salt/api/v2/salt_minions'
           resources :salt_states, only: %i[show index create destroy], controller: '/foreman_salt/api/v2/salt_states'
+          resources :hostgroups, only: %i[show update], controller: '/foreman_salt/api/v2/salt_hostgroups'
         end
 
         resources :salt_variables, only: %i[show index destroy update create], controller: '/foreman_salt/api/v2/salt_variables'

--- a/lib/foreman_salt/plugin.rb
+++ b/lib/foreman_salt/plugin.rb
@@ -22,7 +22,15 @@ Foreman::Plugin.register :foreman_salt do
     caption: N_('Variables'),
     parent: :configure_menu
 
-  # Permissions
+  # Existing permissions
+  p = Foreman::AccessControl.permission(:edit_hostgroups)
+  p.actions << 'foreman_salt/api/v2/salt_hostgroups/update'
+  p.actions << 'hostgroups/salt_environment_selected'
+
+  p = Foreman::AccessControl.permission(:view_hostgroups)
+  p.actions << 'foreman_salt/api/v2/salt_hostgroups/show'
+
+  # New permissions
   security_block :foreman_salt do
     permission :auth_smart_proxies_salt_autosign,
       { 'foreman_salt/api/v2/salt_autosign': [:auth] },
@@ -108,10 +116,6 @@ Foreman::Plugin.register :foreman_salt do
         'foreman_salt/api/v2/salt_minions': %i[index show] },
       resource_type: 'Host'
 
-    permission :edit_hostgroups,
-      { hostgroups: [:salt_environment_selected] },
-      resource_type: 'Hostgroup'
-
     permission :view_smart_proxies_salt_keys,
       { 'foreman_salt/salt_keys': [:index],
         'foreman_salt/api/v2/salt_keys': [:index] },
@@ -164,13 +168,15 @@ Foreman::Plugin.register :foreman_salt do
                         create_salt_environments view_salt_environments
                         edit_salt_environments destroy_salt_environments
                         create_salt_variables view_salt_variables
-                        edit_salt_variables destroy_salt_variables]
+                        edit_salt_variables destroy_salt_variables
+                        view_hostgroups edit_hostgroups]
 
   role 'Salt viewer', %i[view_smart_proxies_salt_keys
                          view_smart_proxies_salt_autosign
                          view_salt_variables
                          view_salt_environments
-                         view_salt_modules]
+                         view_salt_modules
+                         view_hostgroups]
 
   # Parameter filters
   parameter_filter Hostgroup,

--- a/test/functional/api/v2/salt_hostgroups_controller_test.rb
+++ b/test/functional/api/v2/salt_hostgroups_controller_test.rb
@@ -1,0 +1,76 @@
+require 'test_plugin_helper'
+
+module ForemanSalt
+  module Api
+    module V2
+      class SaltHostgroupsControllerTest < ActionController::TestCase
+        setup do
+          @proxy = FactoryBot.create(:smart_proxy, :with_salt_feature)
+          @env = ForemanSalt::SaltEnvironment.create(name: 'basement')
+          @state = ForemanSalt::SaltModule.create(name: 'motd')
+        end
+
+        test 'should show host group' do
+          hostgroup = FactoryBot.create(:hostgroup)
+          get :show, params: { id: hostgroup.id }
+
+          assert_response :success
+          assert_template 'foreman_salt/api/v2/salt_hostgroups/show'
+        end
+
+        test 'should set proxy' do
+          hostgroup = FactoryBot.create(:hostgroup)
+          put :update, params: { id: hostgroup.id, hostgroup: { salt_proxy_id: @proxy.id } }
+          response_json = ActiveSupport::JSON.decode(response.body)
+          # remove protocol and port
+          clean_url = @proxy.url[8..-6]
+
+          assert_response :success
+          assert_template 'foreman_salt/api/v2/salt_hostgroups/update'
+          assert_equal clean_url, response_json['salt_master']
+        end
+
+        test 'should not find proxy' do
+          hostgroup = FactoryBot.create(:hostgroup)
+          put :update, params: { id: hostgroup.id, hostgroup: { salt_proxy_id: -2 } }
+
+          assert_response 422 # unprocessable entity
+        end
+
+        test 'should set environment' do
+          hostgroup = FactoryBot.create(:hostgroup)
+          put :update, params: { id: hostgroup.id, hostgroup: { salt_environment_id: @env.id } }
+          response_json = ActiveSupport::JSON.decode(response.body)
+
+          assert_response :success
+          assert_template 'foreman_salt/api/v2/salt_hostgroups/update'
+          assert_equal @env.name, response_json['salt_environment']
+        end
+
+        test 'should not find environment' do
+          hostgroup = FactoryBot.create(:hostgroup)
+          put :update, params: { id: hostgroup.id, hostgroup: { salt_environment_id: -12 } }
+
+          assert_response 422 # unprocessable entity
+        end
+
+        test 'should set states' do
+          hostgroup = FactoryBot.create(:hostgroup)
+          put :update, params: { id: hostgroup.id, hostgroup: { salt_state_ids: [@state.id] } }
+          response_json = ActiveSupport::JSON.decode(response.body)
+
+          assert_response :success
+          assert_template 'foreman_salt/api/v2/salt_hostgroups/update'
+          assert_equal @state.name, response_json['salt_states'][0]['name']
+        end
+
+        test 'should not find states' do
+          hostgroup = FactoryBot.create(:hostgroup)
+          put :update, params: { id: hostgroup.id, hostgroup: { salt_state_ids: [-5] } }
+
+          assert_response 422 # unprocessable entity
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
Implement new HostgroupController to edit Salt parameters of a host group:

* Add routes for HostGroupController
* Add GET host group for Salt parameters
* Add PUT to edit Salt states, Salt environment, and the Smart Proxy of a host group
* Add API rendering views