### PR TITLE
Fixes #34273 - drop usage of require_ssl_smart_proxies

### DIFF
--- a/test/functional/minions_controller_test.rb
+++ b/test/functional/minions_controller_test.rb
@@ -6,7 +6,6 @@ module ForemanSalt
       User.current = User.anonymous_admin
       Setting::Salt.load_defaults
       Setting[:restrict_registered_smart_proxies] = true
-      Setting[:require_ssl_smart_proxies] = false
 
       @proxy = FactoryBot.create(:smart_proxy, :with_salt_feature)
       Resolv.any_instance.stubs(:getnames).returns([@proxy.to_s])


### PR DESCRIPTION
Setting require_ssl_smart_proxies have been droped from core.
This was used just for tests, that now pass without the setting switched off, as require_ssl is off in tests by default.