### PR TITLE
Remove salt run button on the host page

### DIFF
--- a/app/controllers/foreman_salt/minions_controller.rb
+++ b/app/controllers/foreman_salt/minions_controller.rb
@@ -3,7 +3,7 @@ module ForemanSalt
     include ::Foreman::Controller::SmartProxyAuth
     include ::Foreman::Controller::Parameters::Host
 
-    before_action :find_resource, only: %i[node run]
+    before_action :find_resource, only: %i[node]
     add_smart_proxy_filters :node, features: 'Salt'
 
     def node
@@ -27,15 +27,6 @@ module ForemanSalt
       render(plain: _('Unable to generate output, Check log files\n'), status: :precondition_failed) && return
     end
 
-    def run
-      if @minion.saltrun!
-        success _('Successfully executed, check log files for more details')
-      else
-        error @minion.errors[:base].to_sentence
-      end
-      redirect_to host_path(@minion)
-    end
-
     def salt_environment_selected
       if params[:host][:salt_environment_id].present?
         @salt_environment = ::ForemanSalt::SaltEnvironment.friendly.find(params[:host][:salt_environment_id])
@@ -48,8 +39,6 @@ module ForemanSalt
 
     def action_permission
       case params[:action]
-      when 'run'
-        :saltrun
       when 'node'
         :view
       when 'salt_environment_selected'

--- a/app/helpers/concerns/foreman_salt/hosts_helper_extensions.rb
+++ b/app/helpers/concerns/foreman_salt/hosts_helper_extensions.rb
@@ -11,20 +11,6 @@ module ForemanSalt
            end)]).flatten.compact
       end
 
-      def host_title_actions(host)
-        unless Setting[:salt_hide_run_salt_button]
-          title_actions(
-            button_group(
-              if host.try(:salt_proxy)
-                link_to_if_authorized(_('Run Salt'), { controller: :'foreman_salt/minions', action: :run, id: host },
-                  title: _('Trigger a state.highstate run on a node'), class: 'btn btn-primary')
-              end
-            )
-          )
-        end
-        super(host)
-      end
-
       def multiple_actions
         actions = super
         if authorized_for(controller: :hosts, action: :edit)

--- a/app/models/foreman_salt/concerns/host_managed_extensions.rb
+++ b/app/models/foreman_salt/concerns/host_managed_extensions.rb
@@ -80,18 +80,6 @@ module ForemanSalt
         salt_proxy.to_s
       end
 
-      def saltrun!
-        if salt_proxy.blank?
-          errors.add(:base, _("No Salt master defined - can't continue"))
-          logger.warn 'Unable to execute salt run, no salt proxies defined'
-          return false
-        end
-        ProxyAPI::Salt.new(url: salt_proxy.url).highstate name
-      rescue StandardError => e
-        errors.add(:base, _('Failed to execute state.highstate: %s') % e)
-        false
-      end
-
       def salt_modules_in_host_environment
         return unless salt_modules.any?
 

--- a/app/models/setting/salt.rb
+++ b/app/models/setting/salt.rb
@@ -3,13 +3,7 @@ class Setting
     def self.default_settings
       [
         set('salt_namespace_pillars', N_("Namespace Foreman pillars under 'foreman' key"), false),
-        set('salt_hide_run_salt_button', N_('Hide the Run Salt state.highstate button on the host details page'), false),
       ]
-    end
-
-    def self.load_defaults
-      super
-      Setting['salt_hide_run_salt_button'] = true if ForemanSalt.with_remote_execution?
     end
   end
 end

--- a/db/migrate/20220118160349_drop_salt_hide_run_salt_button_setting.rb
+++ b/db/migrate/20220118160349_drop_salt_hide_run_salt_button_setting.rb
@@ -1,0 +1,5 @@
+class DropSaltHideRunSaltButtonSetting < ActiveRecord::Migration[6.0]
+  def up
+    Setting.where(name: 'salt_hide_run_salt_button').delete_all
+  end
+end

--- a/test/integration/hosts_js_test.rb
+++ b/test/integration/hosts_js_test.rb
@@ -20,22 +20,6 @@ module ForemanSalt
       end
     end
 
-    describe 'hosts details run salt button' do
-      test 'verify run salt button availabilty' do
-        Setting[:salt_hide_run_salt_button] = false
-        visit hosts_path
-        click_link @host.fqdn
-        assert page.has_link?('Run Salt')
-      end
-
-      test 'verify run salt button absence' do
-        Setting[:salt_hide_run_salt_button] = true
-        visit hosts_path
-        click_link @host.fqdn
-        assert_not page.has_link?('Run Salt')
-      end
-    end
-
     describe 'hosts index salt multiple actions' do
       test 'change salt master action' do
         visit hosts_path


### PR DESCRIPTION
The old salt run method doesn't provide feedback or progress
information. Since years, the preferred way to run salt is to use the
according remote execution task.