### PR TITLE
always remove salt key on master

### DIFF
--- a/app/models/foreman_salt/concerns/host_managed_extensions.rb
+++ b/app/models/foreman_salt/concerns/host_managed_extensions.rb
@@ -108,6 +108,7 @@ module ForemanSalt
       private
 
       def ensure_salt_autosign
+        remove_salt_key
         remove_salt_autosign
         create_salt_autosign
       end


### PR DESCRIPTION
With the current implementation, when a host is set to build mode the salt key will not be deleted which will result in a denied key when the minion comes back online with a different public key even though the autosign_grain is there.
I put the remove_salt_key into ensure_salt_autosign since IMHO this should always happen when a host is created or set to build mode (after_build hook). Otherwise the minion will never be able to authenticate with the salt master.