### PR TITLE
Fix Salt key issue on host re-build

### DIFF
--- a/app/models/foreman_salt/concerns/host_managed_extensions.rb
+++ b/app/models/foreman_salt/concerns/host_managed_extensions.rb
@@ -42,6 +42,9 @@ module ForemanSalt
 
         validate :salt_modules_in_host_environment
 
+        # remove minion data in case of a host re-build
+        after_build :remove_salt_minion, if: ->(host) { host.salt_proxy }
+
         after_build :ensure_salt_autosign, if: ->(host) { host.salt_proxy }
         before_destroy :remove_salt_minion, if: ->(host) { host.salt_proxy }
       end


### PR DESCRIPTION
When a host is destroyed, the function `remove_salt_key` is executed which deletes the salt-key on the associated salt-master. This is important to keep the salt-master key store up-to-date with the currently existing hosts.

In case of a re-build, the host key is not removed from the master key store. But, on a host re-build, the host is also completely re-installed which includes the generation of a new Salt authentication key. This leads to a dangling key being kept by the salt-master which hinders the re-built host to authenticate itself since the hostname is still associated with the old key. 

This PR adds a trigger for `remove_salt_key` when a host is build (or re-build).