### PR TITLE
Add support for unhandled highstate error

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -21,7 +21,7 @@ Metrics/AbcSize:
 # Offense count: 1
 # Configuration parameters: CountComments, CountAsOne.
 Metrics/ClassLength:
-  Max: 136
+  Max: 140
 
 # Offense count: 5
 # Configuration parameters: IgnoredMethods.

--- a/app/services/foreman_salt/report_importer.rb
+++ b/app/services/foreman_salt/report_importer.rb
@@ -34,8 +34,8 @@ module ForemanSalt
       @host.salt_proxy_id ||= @proxy_id
       @host.last_report = start_time
 
-      if @raw.is_a? Array
-        process_failures # If Salt sends us only an array, it's a list of fatal failures
+      if [Array, String].member? @raw.class
+        process_failures # If Salt sends us only an array (or string), it's a list of fatal failures
       else
         process_normal
       end
@@ -158,6 +158,7 @@ module ForemanSalt
     end
 
     def process_failures
+      @raw = [@raw] unless @raw.is_a? Array
       status = ConfigReportStatusCalculator.new(counters: { 'failed' => @raw.size }).calculate
       @report = ConfigReport.create(host: @host, reported_at: Time.zone.now, status: status, metrics: {})
 

--- a/test/unit/highstate_unhandled.json
+++ b/test/unit/highstate_unhandled.json
@@ -1,0 +1,3 @@
+{
+  "saltclient713.example.com": "Unhandled exception running state.highstate"
+}

--- a/test/unit/report_importer_test.rb
+++ b/test/unit/report_importer_test.rb
@@ -8,6 +8,7 @@ module ForemanSalt
 
       @report = JSON.parse(File.read(File.join(Engine.root, 'test', 'unit', 'highstate.json')))
       @report_pchanges = JSON.parse(File.read(File.join(Engine.root, 'test', 'unit', 'highstate_pchanges.json')))
+      @report_unhandled = JSON.parse(File.read(File.join(Engine.root, 'test', 'unit', 'highstate_unhandled.json')))
 
       @host = 'saltclient713.example.com'
     end
@@ -54,6 +55,12 @@ module ForemanSalt
       first = reports.first
       assert_equal 'Salt', first.origin
       assert_equal @host, first.host.name
+    end
+
+    test 'importing report with unhandled highstate' do
+      HostStatus::ConfigurationStatus.any_instance.stubs(:relevant?).returns(true)
+      ForemanSalt::ReportImporter.import(@report_unhandled)
+      assert Host.find_by(name: @host).get_status(HostStatus::ConfigurationStatus).error?
     end
   end
 end


### PR DESCRIPTION
When the Master is on high load and the Minion cannot upload a report, it produces an "Unhandled highstate" error report.
This has a particular format and this PR adds support to handle it.

Tests are provided as well. But, the maximum class length has been adapted from `136` to `140`.

Fore more information on the error, see here: [Salt Issue](https://github.com/saltstack/salt/issues/62881)