### PR TITLE
Move newline character out of translation

### DIFF
--- a/app/controllers/foreman_salt/minions_controller.rb
+++ b/app/controllers/foreman_salt/minions_controller.rb
@@ -24,7 +24,7 @@ module ForemanSalt
       end
     rescue StandardError
       logger.warn "Failed to generate external nodes for #{@minion} with #{$ERROR_INFO}"
-      render(plain: _('Unable to generate output, Check log files\n'), status: :precondition_failed) && return
+      render(plain: "#{_('Unable to generate output, Check log files')}\n", status: :precondition_failed) && return
     end
 
     def salt_environment_selected

--- a/locale/de/foreman_salt.po
+++ b/locale/de/foreman_salt.po
@@ -507,10 +507,8 @@ msgstr "Salt States Liste konnten nicht abgerufen werden"
 msgid "Unable to fetch autosign list"
 msgstr "Autosign Liste konnten nicht abgerufen werden"
 
-msgid ""
-"Unable to generate output, Check log files\n"
-msgstr ""
-"Kann keine Ausgabe erzeugen, Bitte Logdateien prüfen\n"
+msgid "Unable to generate output, Check log files"
+msgstr "Kann keine Ausgabe erzeugen, Bitte Logdateien prüfen"
 
 msgid "Unable to reject Salt key for %s"
 msgstr "Salt Schlüssel für %s konnte nicht zurückgewiesen werden"

--- a/locale/en/foreman_salt.po
+++ b/locale/en/foreman_salt.po
@@ -490,10 +490,8 @@ msgstr "Unable to fetch Salt states list"
 msgid "Unable to fetch autosign list"
 msgstr "Unable to fetch autosign list"
 
-msgid ""
-"Unable to generate output, Check log files\n"
-msgstr ""
-"Unable to generate output, Check log files\n"
+msgid "Unable to generate output, Check log files"
+msgstr "Unable to generate output, Check log files"
 
 msgid "Unable to reject Salt key for %s"
 msgstr "Unable to reject Salt key for %s"

--- a/locale/foreman_salt.pot
+++ b/locale/foreman_salt.pot
@@ -273,7 +273,7 @@ msgid "Updated hosts: changed salt environment"
 msgstr ""
 
 #: ../app/controllers/foreman_salt/minions_controller.rb:27
-msgid "Unable to generate output, Check log files\\n"
+msgid "Unable to generate output, Check log files"
 msgstr ""
 
 #: ../app/controllers/foreman_salt/salt_modules_controller.rb:66

--- a/locale/ka/foreman_salt.po
+++ b/locale/ka/foreman_salt.po
@@ -493,10 +493,8 @@ msgstr "მარილის მდგომარეობის სიის 
 msgid "Unable to fetch autosign list"
 msgstr "ავტომატური ხელმოწერის სიის მიღების შეცდომა"
 
-msgid ""
-"Unable to generate output, Check log files\n"
-msgstr ""
-"გამოტანის შეცდომა, შეამოწმეთ ჟურნალი\n"
+msgid "Unable to generate output, Check log files"
+msgstr "გამოტანის შეცდომა, შეამოწმეთ ჟურნალი"
 
 msgid "Unable to reject Salt key for %s"
 msgstr "%s-ის მარილის გასაღების უარყოფის შეცდომა"


### PR DESCRIPTION
This was causing some issues where translators removed it, but then that isn't accepted by gettext. This moves the handling to Ruby where we can better guarantee its behavior.