### PR TITLE
Allow dashes in saltenv names

### DIFF
--- a/app/models/foreman_salt/salt_environment.rb
+++ b/app/models/foreman_salt/salt_environment.rb
@@ -11,7 +11,7 @@ module ForemanSalt
     has_many :salt_module_environments
     has_many :salt_modules, through: :salt_module_environments, before_remove: :remove_from_hosts
 
-    validates :name, uniqueness: true, presence: true, format: { with: /\A[\w\d.]+\z/, message: N_('is alphanumeric and cannot contain spaces') }
+    validates :name, uniqueness: true, presence: true, format: { with: /\A[\w\d\-.]+\z/, message: N_('is alphanumeric and cannot contain spaces') }
 
     scoped_search on: :name, complete_value: true
     scoped_search relation: :hostgroups, on: :name, complete_value: true, rename: :hostgroup


### PR DESCRIPTION
This allows for dashes in saltenv names (e.g. when importing git-branch-backed salt environments like `jira-12345-feature-xyz`). (as discussed here: https://community.theforeman.org/t/salt-state-import-fails-on-3-10-el9-due-to-salt-state-names-being-considered-invalid-for-activerecord/37592/11)

Such environment names are already supported by salt itself, so not being able to use them from foreman is a huge inconvenience. 

(Edit: salt even supports forward slashes in environment names, like in git prefixes "feature/xy" or "pr/abc-def", but that leads to other problems, namely that foreman tries to treat the env-name as an URL part, when syncing, which fails due to the unescaped slash... so not included here, but technically possible)

Please also backport this change to Foreman 3.10.