### PR TITLE
Add GitHub Action to release the gem automatically

### DIFF
--- a/.github/workflows/release_gem.yml
+++ b/.github/workflows/release_gem.yml
@@ -1,0 +1,16 @@
+name: Release
+
+on:
+  push:
+    # Pattern matched against refs/tags
+    tags:
+      - '**'
+
+jobs:
+  release:
+    name: Release gem
+    uses: theforeman/actions/.github/workflows/release-gem.yml@v0
+    with:
+      allowed_owner: theforeman
+    secrets:
+      api_key: ${{ secrets.RUBYGEM_API_KEY }}


### PR DESCRIPTION
Add the GitHub action for an automated gem release, according to [Foreman Ansible](https://github.com/theforeman/foreman_ansible/blob/master/.github/workflows/release_gem.yml).

---
TODO:

- [x] Verify the API key is available in the repo