### PR TITLE
Fixes #37897 - Separate autosign key generation and configuration

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -36,7 +36,7 @@ Metrics/MethodLength:
 # Offense count: 1
 # Configuration parameters: CountComments, CountAsOne.
 Metrics/ModuleLength:
-  Max: 112
+  Max: 150
 
 # Offense count: 5
 # Configuration parameters: IgnoredMethods.


### PR DESCRIPTION
* Replace the update of salt_autosign_key with setting the field after_validation to guarantee that the host is not updated during deployment
* Move the API calls, configuring the autosign key on the corresponding proxy, to an additional orchestration stage to make it visible to the user and reduce delay during validation/saving.